### PR TITLE
chore: align Dependabot config with trend-radar pattern

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,12 +4,12 @@ updates:
     directory: /
     schedule:
       interval: weekly
-    open-pull-requests-limit: 10
     cooldown:
       default-days: 7
     groups:
-      actions-minor:
+      actions-all:
         update-types:
+          - major
           - minor
           - patch
 
@@ -17,16 +17,19 @@ updates:
     directory: /
     schedule:
       interval: weekly
-    open-pull-requests-limit: 10
     cooldown:
-      default-days: 7
+      semver-major-days: 14
+      semver-minor-days: 3
+      semver-patch-days: 3
     groups:
       npm-development:
         dependency-type: development
         update-types:
+          - major
           - minor
           - patch
       npm-production:
         dependency-type: production
         update-types:
+          - minor
           - patch

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,7 @@ updates:
     schedule:
       interval: weekly
     cooldown:
+      default-days: 3
       semver-major-days: 14
       semver-minor-days: 3
       semver-patch-days: 3

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,7 +18,7 @@ updates:
     schedule:
       interval: weekly
     cooldown:
-      default-days: 3
+      default-days: 7
       semver-major-days: 14
       semver-minor-days: 3
       semver-patch-days: 3


### PR DESCRIPTION
Aligns `.github/dependabot.yml` with the pattern established in `chrisreddington/trend-radar` (#217).

## Changes

- **GitHub Actions group**: renamed `actions-minor` → `actions-all` and added `major` to update types
- **npm cooldown**: replaced single `default-days: 7` with semver-specific cooldowns (`semver-major-days: 14`, `semver-minor-days: 3`, `semver-patch-days: 3`)
- **npm-development group**: added `major` updates (was only minor + patch)
- **npm-production group**: added `minor` updates (was only patch)
- **Removed** `open-pull-requests-limit: 10` — not needed with grouping in place

The automerge workflow already matches trend-radar — no changes needed there.